### PR TITLE
Downgrade to Play 2.3.8 (closes #86)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Version {
   val akkaHttp         = "1.0-RC1"
   val jansi            = "1.11"
   val jline            = "2.12"
-  val play             = "2.4.0-M1"
+  val play             = "2.3.8"
   val sbtBundle        = "0.22.0"
   val scalaTest        = "2.2.4"
   val scalactic        = "2.2.4"

--- a/src/main/scala/com/typesafe/conductr/client/package.scala
+++ b/src/main/scala/com/typesafe/conductr/client/package.scala
@@ -29,18 +29,21 @@ package object client {
     override def reads(json: JsValue): JsResult[URI] = implicitly[Format[String]].reads(json).map(new URI(_))
   }
 
-  implicit val uniqueAddressFormat: Format[UniqueAddress] =
-    Json.format
+  implicit val uniqueAddressFormat: Format[UniqueAddress] = Json.format[UniqueAddress]
 
-  implicit val attributesFormat: Format[ConductRController.Attributes] =
-    Json.format
+  // TODO This import is only needed for Play 2.3; with Play 2.4 we can use the qualified return type `Format[ConductRController.Attributes]`
+  import ConductRController.Attributes
+  implicit val attributesFormat: Format[Attributes] = Json.format
 
-  implicit val bundleInstallationFormat: Format[ConductRController.BundleInstallation] =
-    Json.format
+  // TODO This import is only needed for Play 2.3; with Play 2.4 we can use the qualified return type `Format[ConductRController.BundleInstallation]`
+  import ConductRController.BundleInstallation
+  implicit val bundleInstallationFormat: Format[BundleInstallation] = Json.format
 
-  implicit val bundleExecutionFormat: Format[ConductRController.BundleExecution] =
-    Json.format
+  // TODO This import is only needed for Play 2.3; with Play 2.4 we can use the qualified return type `Format[ConductRController.BundleExecution]`
+  import ConductRController.BundleExecution
+  implicit val bundleExecutionFormat: Format[BundleExecution] = Json.format
 
-  implicit val bundleInfoFormat: Format[ConductRController.BundleInfo] =
-    Json.format
+  // TODO This import is only needed for Play 2.3; with Play 2.4 we can use the qualified return type `Format[ConductRController.BundleInfo]`
+  import ConductRController.BundleInfo
+  implicit val bundleInfoFormat: Format[BundleInfo] = Json.format
 }


### PR DESCRIPTION
It looks like in Play 2.4 they have improved the macro for `Json.format` such that it accepts qualified type names like `ConductRController.Attributes`. For Play 2.3 we have to use imports and simple type names like `Attributes`.