### PR TITLE
Addresses global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,49 @@
 
 [![Build Status](https://api.travis-ci.org/sbt/sbt-conductr.png?branch=master)](https://travis-ci.org/sbt/sbt-conductr)
 
-sbt-conductr is an sbt plugin designed to facilitate the development lifecycle at the stage where deployment
-to Typesafe ConductR is required.
+sbt-conductr is an sbt plugin provides commands that communicate with ConductR from within an sbt session. It can
+also be used in conjunction with [sbt-bundle](https://github.com/sbt/sbt-bundle#conductr-bundle-plugin)
+ to deploy your application or service to ConductR without leaving the comforts of sbt.
 
 ## Usage
 
-With the ConductR running you can upload a file using sbt:
+sbt-conductr is enabled by simply declaring its dependency:
 
-```bash
-cd sbt-conductr-tester/
-sbt
+```scala
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
 ```
 
-The above puts you into the console of a test project. The test project is configured to use the sbt-native-packager
-to produce RR bundles, and declares some scheduling configuration. To learn more check out the build.sbt file of this
-same directory.
+The plugin has no requirements for other plugins to be enabled. 
 
-Produce a bundle by typing:
+Unless the ConductR is running at `127.0.0.1:9005`, and instead supposing that it is running at
+`192.168.59.103:9005` then you will typically issue the following command from the sbt console:
+
+```
+controlServer 192.168.59.103:9005
+```
+
+This then sets the sbt session up to subsequently communicate with the ConductR at 192.168.59.103 on port 9005. 
+You may type commands such as:
+
+```
+conduct info
+```
+
+...which will obtain information on the ConductR cluster.
+
+If you have [sbt-bundle](https://github.com/sbt/sbt-bundle#conductr-bundle-plugin) enabled e.g.:
+
+```scala
+lazy val root = (project in file(".")).enablePlugins(JavaAppPackaging)
+```
+
+You can then produce a bundle by typing:
 
 ```bash
 bundle:dist
 ```
 
-A bundle will be produced from the native packager settings of this project. A bundle effectively wraps a native
-packager distribution and includes some component configuration. To load the bundle:
+...and then load the bundle by typing:
 
 ```bash
 conduct load <HIT THE TAB KEY AND THEN RETURN>
@@ -47,46 +66,7 @@ configuration:dist
 
 ...and then hit the tab key after specifying the bundle for `conduct load`.
 
-### To use sbt-typesafe-conductr in your own project
-
-Add the `sbt-conductr` plugin:
-
-```scala
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % "1.0.0")
-```
-
-You must also enable the plugin explicitly for your project:
-
-```scala
-lazy val root = project
-  .in(file("."))
-  .enablePlugins(ConductRPlugin, <your other plugins go here>)
-```
-
-_Note that if you have used Play 2.3 that you must also additionally enable `JavaAppPackaging` for your build e.g.:_
-
-```scala
-enablePlugins(JavaAppPackaging, PlayScala, ConductRPlugin)
-```
-
-_Note also that if you have used a pre 1.0 version of sbt-native-packager then you must remove imports such as the following from your `.sbt` files:_
-
-
-```scala
-import com.typesafe.sbt.SbtNativePackager._
-import NativePackagerKeys._
-```
-
-_...otherwise you will get duplicate imports reported. This is because the new 1.0+ version uses sbt's auto plugin feature._
-
-Unless the ConductR is running at `127.0.0.1:9005`, and instead supposing that it is running at
-`192.168.59.103:9005` then you will typically issue the following command from the sbt console:
-
-```
-controlServer 192.168.59.103:9005
-```
-
-This then sets the sbt session up to subsequently communicate with the ConductR at 192.168.59.103 on port 9005.
+### Settings
 
 The following `sbt-conductr` commands are available:
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,11 @@ import sbt.Resolver.bintrayRepo
 
 object Version {
   val akka             = "2.3.11"
-  val akkaContribExtra = "1.17.0"
-  val akkaHttp         = "1.0-RC3"
+  val akkaContribExtra = "1.18.0"
+  val akkaHttp         = "1.0"
   val jansi            = "1.11"
   val jline            = "2.12"
-  val play             = "2.3.8"
+  val play             = "2.3.10"
   val sbtBundle        = "1.0.0"
   val scalaTest        = "2.2.4"
   val scalactic        = "2.2.4"

--- a/sbt-conductr-tester/build.sbt
+++ b/sbt-conductr-tester/build.sbt
@@ -2,7 +2,7 @@ import ByteConversions._
 
 lazy val root = project
   .in(file("."))
-  .enablePlugins(ConductRPlugin)
+  .enablePlugins(JavaAppPackaging)
 
 name := "sbt-conductr-tester"
 version := "1.0.0"
@@ -16,4 +16,4 @@ BundleKeys.diskSpace := 5.MB
 BundleKeys.roles := Set("web-server")
 BundleKeys.endpoints := Map.empty
 
-configurationName := "web-server"
+BundleKeys.configurationName := "web-server"

--- a/src/main/scala/com/typesafe/conductr/client/ConductRController.scala
+++ b/src/main/scala/com/typesafe/conductr/client/ConductRController.scala
@@ -16,7 +16,7 @@ import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, MediaTypes, Request
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.pattern.pipe
 import akka.stream.actor.ActorPublisher
-import akka.stream.scaladsl.{ Flow, ImplicitFlowMaterializer, Sink, Source }
+import akka.stream.scaladsl.{ Flow, ImplicitMaterializer, Sink, Source }
 import akka.util.{ ByteString, Timeout }
 import java.net.{ URI, URL }
 import play.api.libs.json.Json
@@ -173,7 +173,7 @@ object ConductRController {
  */
 class ConductRController(conductr: Uri, loggingQuery: Uri, connectTimeout: Timeout)
     extends Actor
-    with ImplicitFlowMaterializer {
+    with ImplicitMaterializer {
 
   import ConductRController._
   import context.dispatcher

--- a/src/main/scala/com/typesafe/conductr/sbt/ConductR.scala
+++ b/src/main/scala/com/typesafe/conductr/sbt/ConductR.scala
@@ -13,7 +13,7 @@ import akka.util.Timeout
 import com.typesafe.conductr.client.ConductRController
 import com.typesafe.conductr.client.ConductRController.{ LoadBundle, RunBundle, StopBundle, UnloadBundle }
 import org.scalactic.{ Accumulation, Bad, Good, One, Or }
-import play.api.libs.json.{ JsString, Json }
+import play.api.libs.json.{ JsError, JsSuccess, JsString, Json }
 import sbt._
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }
@@ -51,12 +51,12 @@ private[conductr] object ConductR {
           Await.ready(response, loadTimeout.duration)
           response.value.get match {
             case Success(s) =>
-              Json.parse(s) \ "bundleId" match {
-                case JsString(bundleId) =>
+              (Json.parse(s) \ "bundleId").validate[String] match {
+                case JsSuccess(bundleId, _) =>
                   state.log.info(s"Upload completed. Use 'conduct run $bundleId' to run.")
                   bundleId
-                case other =>
-                  sys.error(s"Unexpected response: $other")
+                case e: JsError =>
+                  sys.error(s"Unexpected response: $e")
               }
             case Failure(e) =>
               sys.error(s"Problem loading the bundle: ${e.getMessage}")
@@ -77,12 +77,12 @@ private[conductr] object ConductR {
       Await.ready(response, requestTimeout.duration)
       response.value.get match {
         case Success(s) =>
-          Json.parse(s) \ "requestId" match {
-            case JsString(requestId) =>
+          (Json.parse(s) \ "requestId").validate[String] match {
+            case JsSuccess(requestId, _) =>
               state.log.info(s"Request for running has been delivered with id: $requestId")
               requestId
-            case other =>
-              sys.error(s"Unexpected response: $other")
+            case e: JsError =>
+              sys.error(s"Unexpected response: $e")
           }
         case Failure(e) =>
           sys.error(s"Problem running the bundle: ${e.getMessage}")
@@ -96,12 +96,12 @@ private[conductr] object ConductR {
       Await.ready(response, requestTimeout.duration)
       response.value.get match {
         case Success(s) =>
-          Json.parse(s) \ "requestId" match {
-            case JsString(requestId) =>
+          (Json.parse(s) \ "requestId").validate[String] match {
+            case JsSuccess(requestId, _) =>
               state.log.info(s"Request for stopping has been delivered with id: $requestId")
               requestId
-            case other =>
-              sys.error(s"Unexpected response: $other")
+            case e: JsError =>
+              sys.error(s"Unexpected response: $e")
           }
         case Failure(e) =>
           sys.error(s"Problem stopping the bundle: ${e.getMessage}")
@@ -115,12 +115,12 @@ private[conductr] object ConductR {
       Await.ready(response, requestTimeout.duration)
       response.value.get match {
         case Success(s) =>
-          Json.parse(s) \ "requestId" match {
-            case JsString(requestId) =>
+          (Json.parse(s) \ "requestId").validate[String] match {
+            case JsSuccess(requestId, _) =>
               state.log.info(s"Request for unloading has been delivered with id: $requestId")
               requestId
-            case other =>
-              sys.error(s"Unexpected response: $other")
+            case e: JsError =>
+              sys.error(s"Unexpected response: $e")
           }
         case Failure(e) =>
           sys.error(s"Problem unloading the bundle: ${e.getMessage}")

--- a/src/main/scala/com/typesafe/conductr/sbt/console/Screen.scala
+++ b/src/main/scala/com/typesafe/conductr/sbt/console/Screen.scala
@@ -6,7 +6,7 @@ package com.typesafe.conductr.sbt
 package console
 
 import akka.actor.{ Actor, Props, Status }
-import akka.stream.scaladsl.{ ImplicitFlowMaterializer, Sink }
+import akka.stream.scaladsl.{ ImplicitMaterializer, Sink }
 import com.typesafe.conductr.client.ConductRController
 import jline.TerminalFactory
 import scala.concurrent.duration.DurationInt
@@ -27,7 +27,7 @@ object Screen {
  * Draws data to the screen. Data is subscribed from a ConductRController.BundleInfo flow,
  * which is received in a ConductRController.BundleInfosSource message and then materialized.
  */
-class Screen[A <: Iterable[B], B](refresh: Boolean, layout: A => Screen.Layout) extends Actor with ImplicitFlowMaterializer {
+class Screen[A <: Iterable[B], B](refresh: Boolean, layout: A => Screen.Layout) extends Actor with ImplicitMaterializer {
 
   import AnsiConsole.Implicits._
   import Column._


### PR DESCRIPTION
As there is just one ConductR running in the background the scope of most settings should be global.

Input parsing has also been tidied up.

Also upgraded the plugin's dependencies to the latest versions including akka-http.

Fixes #99 
Fixes #98