### PR TITLE
Implementation of events and logs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,32 @@ configuration:dist
 
 ...and then hit the tab key after specifying the bundle for `conduct load`.
 
+### Retrieve logs and events
+
+The log messages and events of a particular bundle can be displayed with the commands:
+
+```bash
+conduct logs my-bundle
+conduct events my-bundle
+```
+
+Make sure that your logging infrastructure is up an running. Otherwise the command will timeout: 
+
+```
+[trace] Stack trace suppressed: run last conductr-service-lookup/*:conduct for the full output.
+[error] (conductr-service-lookup/*:conduct) java.util.concurrent.TimeoutException: Futures timed out after [5 seconds]
+[error] Total time: 5 s, completed Sep 28, 2015 11:40:47 AM
+```
+
+With [sbt-conductr-sandbox](https://github.com/typesafehub/sbt-conductr-sandbox) you can start the default logging infrastructure during ConductR cluster startup easily:
+
+```bash
+sandbox run --withFeatures logging
+conduct logs my-bundle
+```
+
+Give the logging infrastructure enough time to start before entering the `logs` or `events` command.
+
 ### Settings
 
 The following `sbt-conductr` commands are available:
@@ -78,6 +104,8 @@ conduct load           | Loads a bundle and an optional configuration to the Con
 conduct run            | Runs a bundle given a bundle id with an optional absolute scale value specified with --scale
 conduct stop           | Stops all executions of a bundle given a bundle id
 conduct unload         | Unloads a bundle entirely (requires that the bundle has stopped executing everywhere)
+conduct logs           | Retrieves log messages of a given bundle
+conduct events         | Retrieves events of a given bundle
 
 In addition the following settings are available:
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ libraryDependencies ++= List(
   Library.akkaHttp,
   Library.jansi,
   Library.jline,
+  Library.jodaTime,
   Library.playJson,
   Library.scalactic,
   Library.akkaTestkit % "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Version {
   val akkaHttp         = "1.0"
   val jansi            = "1.11"
   val jline            = "2.12"
+  val jodaTime         = "2.8.2"
   val play             = "2.3.10"
   val sbtBundle        = "1.1.0"
   val scalaTest        = "2.2.4"
@@ -19,6 +20,7 @@ object Library {
   val akkaTestkit      = "com.typesafe.akka"    %% "akka-testkit"           % Version.akka
   val jansi            = "org.fusesource.jansi" %  "jansi"                  % Version.jansi
   val jline            = "jline"                %  "jline"                  % Version.jline
+  val jodaTime         = "joda-time"            %  "joda-time"              % Version.jodaTime
   val playJson         = "com.typesafe.play"    %% "play-json"              % Version.play
   val sbtBundle        = "com.typesafe.sbt"     %  "sbt-bundle"             % Version.sbtBundle
   val scalaTest        = "org.scalatest"        %% "scalatest"              % Version.scalaTest

--- a/src/main/scala/com/typesafe/conductr/sbt/ConductR.scala
+++ b/src/main/scala/com/typesafe/conductr/sbt/ConductR.scala
@@ -143,13 +143,15 @@ private[conductr] object ConductR {
   def info(apiVersion: String, state: State): Unit =
     withActorSystem(state)(withConductRController(state)(console.Console.bundleInfo(toApiVersion(apiVersion), refresh = false)))
 
-  def events(apiVersion: String, bundleId: String, state: State): Unit =
-    println("This command is not yet available. Consult ConductR logs.")
-  //withActorSystem(s)(withConductRController(s)(console.Console.events(bundleId, refresh = false))) FIXME
+  def events(apiVersion: String, bundleId: String, lines: Option[Int], state: State): Unit =
+    withActorSystem(state) {
+      withConductRController(state)(console.Console.bundleEvents(toApiVersion(apiVersion), bundleId, lines.getOrElse(10), refresh = false))
+    }
 
-  def logs(apiVersion: String, bundleId: String, state: State): Unit =
-    println("This command is not yet available. Consult your application logs.")
-  //withActorSystem(s)(withConductRController(s)(console.Console.logs(bundleId, refresh = false))) FIXME
+  def logs(apiVersion: String, bundleId: String, lines: Option[Int], state: State): Unit =
+    withActorSystem(state) {
+      withConductRController(state)(console.Console.bundleLogs(toApiVersion(apiVersion), bundleId, lines.getOrElse(10), refresh = false))
+    }
 
   def envUrl(envIp: String, defaultIp: String, envPort: String, defaultPort: Int, defaultProto: String): URL = {
     val ip = sys.env.getOrElse(envIp, defaultIp)

--- a/src/main/scala/com/typesafe/conductr/sbt/console/Console.scala
+++ b/src/main/scala/com/typesafe/conductr/sbt/console/Console.scala
@@ -17,7 +17,7 @@ import com.typesafe.conductr.sbt.console.Column._
 object Console {
 
   import scala.concurrent.duration._
-  val timeout = 10.second
+  val timeout = 5.seconds
 
   def bundleInfo(apiVersion: ConductRController.ApiVersion.Value, refresh: Boolean): ActorRef => ActorSystem => Unit = { implicit conductr =>
     { implicit system =>
@@ -44,7 +44,7 @@ object Console {
     }
   }
 
-  def events(apiVersion: ConductRController.ApiVersion.Value, bundleId: String, refresh: Boolean): ActorRef => ActorSystem => Unit = { implicit conductr =>
+  def bundleEvents(apiVersion: ConductRController.ApiVersion.Value, bundleId: String, lines: Int, refresh: Boolean): ActorRef => ActorSystem => Unit = { implicit conductr =>
     { implicit system =>
 
       import system.dispatcher
@@ -58,7 +58,7 @@ object Console {
         Screen.Layout(columns, Vector.empty)
       }), "screen")
       conductr
-        .ask(ConductRController.GetEventStream(apiVersion, bundleId))(timeout)
+        .ask(ConductRController.GetBundleEvents(apiVersion, bundleId, lines))(timeout)
         .mapTo[ConductRController.DataSource[Seq[ConductRController.Event]]]
         .pipeTo(screen)
 
@@ -66,7 +66,7 @@ object Console {
     }
   }
 
-  def logs(apiVersion: ConductRController.ApiVersion.Value, bundleId: String, refresh: Boolean): ActorRef => ActorSystem => Unit = { implicit conductr =>
+  def bundleLogs(apiVersion: ConductRController.ApiVersion.Value, bundleId: String, lines: Int, refresh: Boolean): ActorRef => ActorSystem => Unit = { implicit conductr =>
     { implicit system =>
 
       import system.dispatcher
@@ -80,7 +80,7 @@ object Console {
         Screen.Layout(columns, Vector.empty)
       }), "screen")
       conductr
-        .ask(ConductRController.GetLogStream(apiVersion, bundleId))(timeout)
+        .ask(ConductRController.GetBundleLogs(apiVersion, bundleId, lines))(timeout)
         .mapTo[ConductRController.DataSource[Seq[ConductRController.Log]]]
         .pipeTo(screen)
 
@@ -124,5 +124,4 @@ object Console {
       }
     }
   }
-
 }


### PR DESCRIPTION
Implementation of the commands `events` and `logs`. Syntax:

```
conduct logs visualizer
conduct logs conductr-kibana --scale 50
conduct events visualizer
conduct events conductr-kibana --scale 50
```

The last parameter 50 is optional and tells how many lines should be displayed.

The logs and events are getting retrieved. However, the PR isn't finished yet. Missing pieces are:
- Nice formatting of output

Also refactored the `src/main/scala/com/typesafe/conductr/client/ConductRController.scala` by encapsulating duplicated code into methods.
