### PR TITLE
Fix wrong cursor position in conduct info, events, logs

### DIFF
--- a/src/main/scala/com/typesafe/conductr/sbt/console/Console.scala
+++ b/src/main/scala/com/typesafe/conductr/sbt/console/Console.scala
@@ -92,14 +92,14 @@ object Console {
 
     import system.dispatcher
 
-    print(Ansi.ansi().saveCursorPosition())
-
     if (refresh) {
+      print(Ansi.ansi().saveCursorPosition())
       val con = new ConsoleReader()
       blocking {
         con.readCharacter('q')
       }
       system.stop(screen)
+      print(Ansi.ansi().restorCursorPosition())
     } else {
       // There is no way to wait for actor termination from a non-actor,
       // other than using gracefulStop with a message that does nothing.
@@ -109,8 +109,6 @@ object Console {
       }
       Await.ready(f, timeout)
     }
-
-    print(Ansi.ansi().restorCursorPosition())
   }
 
   object Implicits {


### PR DESCRIPTION
Fixes issue #102.

So far the cursor position has been saved and restored after the output has been rendered. This resulted into having the sbt console cursor inside of the output. 

Not sure why this logic has been applied in the first place.
@huntc: Do you have any insights here?

The refresh mode is currently not used by any of the commands.