### PR TITLE
Throw error if http status code 300

### DIFF
--- a/src/main/scala/com/typesafe/conductr/client/ConductRController.scala
+++ b/src/main/scala/com/typesafe/conductr/client/ConductRController.scala
@@ -221,7 +221,7 @@ class ConductRController(conductr: Uri, loggingQuery: Uri, connectTimeout: Timeo
 
   private def httpRequest[A: Reads](method: HttpMethod, uri: String, entity: Option[RequestEntity] = None, parse: Boolean = false): Future[A] = {
     def bodyOrThrow(response: HttpResponse, body: String): String =
-      if (response.status.isSuccess()) body else throw new IllegalStateException(body)
+      if (response.status.isSuccess() && response.status != StatusCodes.MultipleChoices) body else throw new IllegalStateException(body)
 
     val req = entity.map(e => HttpRequest(method, uri, entity = e)).getOrElse(HttpRequest(method, uri))
     for {


### PR DESCRIPTION
ConductR is returning the status code 300 '300 Multiple Choices' in case the http request is ambiguous. in Akka HTTP the status code 300 is part of the `redirection` group. The redirection group returns `true` for the method `status.isSuccess`. In `sbt-conductr` we only validated the status code based on the method `status.isSuccess`. Now an additional check has been added which is validating if the status code is 300. If that is the case an `IllegalStateException` is thrown, as with other errors.