### PR TITLE
Adding usage info to conduct commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ The following `sbt-conductr` commands are available:
 
 Property               | Description
 -----------------------|------------
-conduct info           | Gain infomation on the cluster
+conduct help           | Get usage information of the conduct command
+conduct info           | Gain information on the cluster
 conduct load           | Loads a bundle and an optional configuration to the ConductR
 conduct run            | Runs a bundle given a bundle id with an optional absolute scale value specified with --scale
 conduct stop           | Stops all executions of a bundle given a bundle id


### PR DESCRIPTION
The conduct commands provide now helpful usage information in case the command was not used correctly:
- `conduct` | `conduct help` => Usage information of conduct command
- `conduct [subtask] => Usage information of the particular subtask (only if the parsing of the command failed)

The usage information are the same as on `conductr-cli`.