### PR TITLE
Better error handling to resolve host ip

### DIFF
--- a/src/main/scala/com/typesafe/conductr/sbt/ConductR.scala
+++ b/src/main/scala/com/typesafe/conductr/sbt/ConductR.scala
@@ -27,7 +27,7 @@ private[conductr] object ConductR {
   import Import._
 
   final val DefaultConductrProtocol = "http"
-  final val DefaultConductrHost = ConductRPlugin.resolveDefaultHostIp
+  final val DefaultConductrHost = ConductRPlugin.resolveDefaultHostIp()
   final val DefaultConductrPort = 9005
 
   val conductrAttrKey = AttributeKey[ActorRef]("sbt-conductr")
@@ -219,7 +219,7 @@ private[conductr] object ConductR {
             loggingQueryUrl <- (ConductRKeys.conductrLoggingQueryUrl in Global).get(settings)
             connectTimeout <- (ConductRKeys.conductrConnectTimeout in Global).get(settings)
           } yield {
-            state.log.info(s"Control Protocol set for $conductrUrl. Use `controlServer` to set an alternate address.")
+            state.log.info(s"Control Protocol set for $conductrUrl. Use 'controlServer {ip-address}' to set an alternate address.")
             system.actorOf(ConductRController.props(HttpUri(conductrUrl.toString), HttpUri(loggingQueryUrl.toString), connectTimeout))
           }
         conductr.getOrElse(sys.error("Cannot establish the ConductRController actor: Check that you have conductrControlServerUrl and conductrConnectTimeout settings!"))

--- a/src/main/scala/com/typesafe/conductr/sbt/console/AnsiConsole.scala
+++ b/src/main/scala/com/typesafe/conductr/sbt/console/AnsiConsole.scala
@@ -54,6 +54,15 @@ object AnsiConsole {
        */
       def visibleLength: Int =
         s.replaceAll("""@\|[a-z_,]+ ([^\|]+)\|@""", "$1").length
+
+      def asInfo: String =
+        s"[info] $s"
+
+      def asWarn: String =
+        s"[${scala.Console.YELLOW}warn${scala.Console.RESET}] $s"
+
+      def asError: String =
+        s"[${scala.Console.RED}error${scala.Console.RESET}] $s"
     }
 
   }


### PR DESCRIPTION
The current error handling of `docker-machine` is not optimal. If the VM has not been started with `docker-machine start default` and the user start the sbt session then he will only see this output currently:

```
...
host is not running
[info] Set current project to sbt-conductr-tester (in build file:/Users/mj/workspace/sbt-conductr/sbt-conductr-tester/)
[info] Control Protocol set for http://:9005. Use 'controlServer {ip-address}' to set an alternate address.
```

The error message `host is not running` comes straight from docker machine. The user doesn't now what to do here. This PR improves the output if the VM has not been started yet with `docker-machine`. The new output is:

```
...
host is not running
[warn] Docker VM has not been started. Use 'docker-machine start default' in the terminal to start the VM and reload the sbt session.
[info] Set current project to sbt-conductr-tester (in build file:/Users/mj/workspace/sbt-conductr/sbt-conductr-tester/)
[info] Control Protocol set for http://:9005. Use 'controlServer {ip-address}' to set an alternate address.
```

The new warning is color coded with `println` instead of using `state.log` logger. The logger can't be used here because the method `resolveDefaultHostIp` is called when no state is available (e.g. in ConductR acceptance tests).

The error handling for `boot2docker` stays the same. If both `docker-machine` and `boot2docker` and the `hostname` command doesn't exist then the default ip address `127.0.0.1` is returned. 

@huntc: Instead of returning `127.0.0.1` we could also throw a warning saying that docker need to be installed. This case can only occur in windows scenarios.

@huntc: Can you do a review?