### PR TITLE
No not set empty command seq

### DIFF
--- a/src/main/scala/com/typesafe/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/typesafe/conductr/sbt/ConductRPlugin.scala
@@ -35,7 +35,6 @@ object ConductRPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[_]] =
     super.projectSettings ++ List(
-      Keys.commands ++= Seq.empty,
       ConductRKeys.conduct := conductTask.value.evaluated,
 
       ConductRKeys.conductrDiscoveredDist <<=


### PR DESCRIPTION
Removes uneccessary line that adds an empty `Seq` to the the `Keys.commands` key.