### PR TITLE
Change package to com.lightbend.conductr

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,7 @@ object Build extends AutoPlugin {
     releaseSettings ++
     List(
       // Core settings
-      organization := "com.typesafe.conductr",
+      organization := "com.lightbend.conductr",
       crossScalaVersions := List(scalaVersion.value),
       scalacOptions ++= List(
         "-unchecked",

--- a/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/ConductRPlugin.scala
@@ -2,7 +2,7 @@
  * Copyright © 2016 Lightbend, Inc. All rights reserved.
  */
 
-package com.typesafe.conductr.sbt
+package com.lightbend.conductr.sbt
 
 import sbt._
 import sbt.Keys._

--- a/src/main/scala/com/lightbend/conductr/sbt/Import.scala
+++ b/src/main/scala/com/lightbend/conductr/sbt/Import.scala
@@ -2,7 +2,7 @@
  * Copyright © 2014-2016 Lightbend, Inc. All rights reserved.
  */
 
-package com.typesafe.conductr.sbt
+package com.lightbend.conductr.sbt
 
 import sbt._
 

--- a/src/sbt-test/sbt-conductr/conduct-common-args/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/conduct-common-args/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr/conduct-end-to-end/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/conduct-end-to-end/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr/sandbox-all-args/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-all-args/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr/sandbox-basic/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-basic/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr/sandbox-conductr-roles/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-conductr-roles/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr/sandbox-ports-basic/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-basic/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr/sandbox-ports-multi-module/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-ports-multi-module/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr/sandbox-scaling/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-scaling/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr/sandbox-with-features/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-with-features/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"

--- a/src/sbt-test/sbt-conductr/sandbox-with-rp-license/project/plugins.sbt
+++ b/src/sbt-test/sbt-conductr/sandbox-with-rp-license/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr" % sys.props("project.version"))
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % sys.props("project.version"))
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.4"


### PR DESCRIPTION
- Change package of sbt-conductr to `com.lightbend.conductr.sbt`
- Change organization to `com.lightbend.conductr`

The README hasn't been updated on purposes because this version is not published yet. Before we publish the new version we will update the README accordingly to reflect the new organization name.