### PR TITLE
Removing unneccesary resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,11 +8,6 @@ crossScalaVersions := List(scalaVersion.value, "2.11.7")
 
 addSbtPlugin(Library.sbtBundle)
 
-resolvers ++= List(
-  Resolver.typesafeReleases,
-  Resolver.typesafeBintrayReleases
-)
-
 sbtPlugin := true
 
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,4 @@
 import sbt._
-import sbt.Resolver.bintrayRepo
 
 object Version {
   val sbtBundle         = "1.3.2"
@@ -8,9 +7,4 @@ object Version {
 
 object Library {
   val sbtBundle         = "com.typesafe.sbt"      %  "sbt-bundle"                 % Version.sbtBundle
-}
-
-object Resolver {
-  val typesafeReleases        = "typesafe-releases" at "http://repo.typesafe.com/typesafe/maven-releases"
-  val typesafeBintrayReleases = bintrayRepo("typesafe", "maven-releases")
 }


### PR DESCRIPTION
Tested this version with a new project that brings in `sbt-conductr`.